### PR TITLE
Correct docblock type value for valueInSeconds to int

### DIFF
--- a/src/webignition/ReadableDuration/ReadableDuration.php
+++ b/src/webignition/ReadableDuration/ReadableDuration.php
@@ -77,7 +77,7 @@ class ReadableDuration {
     
     /**
      * 
-     * @param type $valueInSeconds
+     * @param int $valueInSeconds
      */
     public function __construct($valueInSeconds = null) {
         $this->setValueInSeconds($valueInSeconds);
@@ -86,7 +86,7 @@ class ReadableDuration {
     
     /**
      * 
-     * @param type $valueInSeconds
+     * @param int $valueInSeconds
      * @return \webignition\ReadableDuration\ReadableDuration
      */
     public function setValueInSeconds($valueInSeconds) {


### PR DESCRIPTION
With the existing docblock, my IDE (phpstorm) thinks that the setValueInSeconds method is expecting an object of type '\webignition\ReadableDuration\type', when really it just wants an int.
